### PR TITLE
Configuring Hive in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.ssh.forward_x11 = true
   config.ssh.forward_agent = true
+  config.vm.provision "file", source: "./hive-site.xml", destination: "hive-site.xml"
 
   config.vm.provider "virtualbox" do |vb|
      vb.memory = "2048"
@@ -56,6 +57,15 @@ Vagrant.configure("2") do |config|
       pip install markdown
       pip install testresources
       pip install mrjob --ignore-installed six
+
+      # Setup schema for Hive
+      mkdir /var/warehouse
+      chmod -R 777 /var/warehouse
+      mv /home/vagrant/hive-site.xml /usr/lib/hive/apache-hive-2.3.4-bin/conf/
+      echo '\n\n export HADOOP_HOME="/usr/local/hadoop"'
+      echo 'if [ ! -d "/var/warehouse/metastore_db" ]; then' >> /home/vagrant/.bashrc
+      echo '  /usr/lib/hive/apache-hive-2.3.4-bin/bin/schematool -dbType derby -initSchema' >> /home/vagrant/.bashrc
+      echo 'fi' >> /home/vagrant/.bashrc
 
    SHELL
 

--- a/hive-site.xml
+++ b/hive-site.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+<property>
+    <name>hive.metastore.warehouse.dir</name>
+    <value>/var/warehouse</value>
+    <description>
+    Local or HDFS directory where Hive keeps table contents.
+    </description>
+</property>
+<property>
+    <name>hive.metastore.local</name>
+    <value>true</value>
+    <description>
+    Use false if a production metastore server is used.
+    </description>
+</property>
+<property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:derby:;databaseName=/var/warehouse/metastore_db;create=true</value>
+    <description>
+    The JDBC connection URL.
+    </description>
+</property>
+</configuration>


### PR DESCRIPTION
- Added script to automatically configure hive storage. 
- Hive commands would normally work without MetaStoreException.
- Hive metastoreDB is configured to /var/warehouse which is an ideal location, Hive is configured to use this in hive-site.xml
- hive-site.xml will be configured automatically by vagrant
